### PR TITLE
Update dependencies for CRAM4

### DIFF
--- a/cram_giskard_manager/cram-giskard-manager.asd
+++ b/cram_giskard_manager/cram-giskard-manager.asd
@@ -31,7 +31,7 @@
   :license "BSD"
 
   :depends-on (cram-language
-               cram-plan-failures
+               cram-common-failures
                cram-prolog
                cram-utilities
                cl-giskard

--- a/cram_giskard_manager/package.xml
+++ b/cram_giskard_manager/package.xml
@@ -17,7 +17,7 @@
 
   <!-- Dependencies needed to compile this package. -->
   <build_depend>cram_language</build_depend>
-  <build_depend>cram_plan_failures</build_depend>
+  <build_depend>cram_common_failures</build_depend>
   <build_depend>cram_prolog</build_depend>
   <build_depend>cram_utilities</build_depend>
   <!-- <build_depend>cl_giskard</build_depend> -->
@@ -25,7 +25,7 @@
   
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>cram_language</run_depend>
-  <run_depend>cram_plan_failures</run_depend>
+  <run_depend>cram_common_failures</run_depend>
   <run_depend>cram_prolog</run_depend>
   <run_depend>cram_utilities</run_depend>
   <!-- <run_depend>cl_giskard</run_depend> -->

--- a/cram_giskard_manager/src/failures.lisp
+++ b/cram_giskard_manager/src/failures.lisp
@@ -28,7 +28,7 @@
 
 (in-package :cram-giskard-manager)
 
-(define-condition giskard-failure (cram-plan-failures:manipulation-failure) ())
+(define-condition giskard-failure (cram-common-failures:manipulation-low-level-failure) ())
 
 (define-condition bad-goal-spec (giskard-failure) ())
 

--- a/cram_manipulation/package.xml
+++ b/cram_manipulation/package.xml
@@ -11,10 +11,9 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>cram_tf</run_depend>
-  <run_depend>cram_plan_failures</run_depend>
+  <run_depend>cram_common_failures</run_depend>
   <run_depend>cram_prolog</run_depend>
   <run_depend>cram_plan_occasions_events</run_depend>
-  <run_depend>cram_plan_library</run_depend>
   <run_depend>cram_robot_interfaces</run_depend>
 
   <export>

--- a/cram_motion_manager/cram-motion-manager.asd
+++ b/cram_motion_manager/cram-motion-manager.asd
@@ -32,7 +32,7 @@
 
   :depends-on (cram-language
                cram-designators
-               cram-plan-failures
+               cram-common-failures
                cram-robot-interfaces
                alexandria
                cram-prolog

--- a/cram_motion_manager/package.xml
+++ b/cram_motion_manager/package.xml
@@ -18,7 +18,7 @@
   <!-- Dependencies needed to compile this package. -->
   <build_depend>cram_language</build_depend>
   <build_depend>cram_designators</build_depend>
-  <build_depend>cram_plan_failures</build_depend>
+  <build_depend>cram_common_failures</build_depend>
   <build_depend>cram_robot_interfaces</build_depend>
   <build_depend>alexandria</build_depend>
   <build_depend>cram_prolog</build_depend>
@@ -28,7 +28,7 @@
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>cram_language</run_depend>
   <run_depend>cram_designators</run_depend>
-  <run_depend>cram_plan_failures</run_depend>
+  <run_depend>cram_common_failures</run_depend>
   <run_depend>cram_robot_interfaces</run_depend>
   <run_depend>alexandria</run_depend>
   <run_depend>cram_prolog</run_depend>

--- a/cram_moveit_manager/cram-moveit-manager.asd
+++ b/cram_moveit_manager/cram-moveit-manager.asd
@@ -31,7 +31,7 @@
   :license "BSD"
 
   :depends-on (cram-language
-               cram-plan-failures
+               cram-common-failures
                cram-prolog
                cram-utilities
                cram-moveit

--- a/cram_moveit_manager/package.xml
+++ b/cram_moveit_manager/package.xml
@@ -17,7 +17,7 @@
 
   <!-- Dependencies needed to compile this package. -->
   <build_depend>cram_language</build_depend>
-  <build_depend>cram_plan_failures</build_depend>
+  <build_depend>cram_common_failures</build_depend>
   <build_depend>cram_prolog</build_depend>
   <build_depend>cram_utilities</build_depend>
   <build_depend>cram_moveit</build_depend>
@@ -25,7 +25,7 @@
   
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>cram_language</run_depend>
-  <run_depend>cram_plan_failures</run_depend>
+  <run_depend>cram_common_failures</run_depend>
   <run_depend>cram_prolog</run_depend>
   <run_depend>cram_utilities</run_depend>
   <run_depend>cram_moveit</run_depend>


### PR DESCRIPTION
Removed deps on cram-plan-failures, cram-plan-library